### PR TITLE
add cache tags and invalidate route

### DIFF
--- a/actions/get-categories.tsx
+++ b/actions/get-categories.tsx
@@ -2,7 +2,9 @@ const URL = `https://${process.env.NEXT_PUBLIC_DUMMYJSON_URL}/products/categorie
 
 const getCategories = async (): Promise<string[]> => {
 	try {
-		const res = await fetch(URL);
+		const res = await fetch(URL, {
+			next: { tags: [`categories`] },
+		});
 		const categories = await res.json();
 
 		return categories;

--- a/actions/get-product.tsx
+++ b/actions/get-product.tsx
@@ -4,7 +4,9 @@ const URL = `https://${process.env.NEXT_PUBLIC_DUMMYJSON_URL}/products`;
 
 const getProduct = async (id: number): Promise<Product | null> => {
 	try {
-		const res = await fetch(`${URL}/${id}`);
+		const res = await fetch(`${URL}/${id}`, {
+			next: { tags: [`product-${id}`, `product`] },
+		});
 
 		const product = res.json();
 		return product;

--- a/actions/get-products.tsx
+++ b/actions/get-products.tsx
@@ -29,7 +29,16 @@ const getProducts = async (query: Query): Promise<Product[]> => {
 			skip: query.skip,
 		},
 	});
-	const res = await fetch(url);
+
+	const queryCacheKey = `products-${
+		typeof query.category === 'undefined' ? 'all' : query.category
+	}-${query.limit}-${query.skip}`;
+
+	const res = await fetch(url, {
+		next: {
+			tags: [queryCacheKey, `products`],
+		},
+	});
 
 	const { products } = await res.json();
 	if (res.ok) {

--- a/app/(routes)/cart/page.tsx
+++ b/app/(routes)/cart/page.tsx
@@ -8,8 +8,6 @@ import useCart from '@/hooks/use-cart';
 import Summary from '@/components/ui/cart/summary';
 import CartItem from '@/components/ui/cart/cart-item';
 
-export const revalidate = 0;
-
 const CartPage = () => {
 	const [isMounted, setIsMounted] = useState(false);
 	const cart = useCart();

--- a/app/(routes)/page.tsx
+++ b/app/(routes)/page.tsx
@@ -5,8 +5,6 @@ import ProductList from "@/components/ui/product-list";
 import ProductsFilter from "@/components/ui/products-filter/index";
 import { getProductsPriceRange } from "@/lib/utils";
 
-export const revalidate = 0;
-
 const HomePage = async ({
   searchParams,
 }: {

--- a/app/(routes)/product/[productId]/page.tsx
+++ b/app/(routes)/product/[productId]/page.tsx
@@ -10,8 +10,6 @@ interface ProductPageProps {
   };
 }
 
-export const revalidate = 0;
-
 const ProductPage: React.FC<ProductPageProps> = async ({ params }) => {
   const product = await getProduct(params.productId);
 

--- a/app/api/v1/revalidate/route.ts
+++ b/app/api/v1/revalidate/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { revalidateTag } from 'next/cache';
+
+export async function GET(request: NextRequest) {
+	const tag = request.nextUrl.searchParams.get('tag');
+
+	if (!tag) {
+		return NextResponse.json({
+			revalidated: false,
+			msg: 'you need to provide query param ?tag={cache-tag}',
+		});
+	}
+	revalidateTag(tag);
+	console.log(`cache invalidated for tag ${tag} at ${Date.now()}`);
+	return NextResponse.json({ revalidated: true, now: Date.now() });
+}


### PR DESCRIPTION
## Context
Previously all api calls are not cache by default. Now Nextjs is caching for all fetch request with unique tags.

- Each routes have individual tag and catch all tag to allow fine-grained control of the pages.
- Example for product detail page - ```next: { tags: [`product-${id}`, `product`] }``` 
- Decided to go with this on demand revalidating instead of background cache revalidating is because this would more efficient way of caching rarely updated pages. 
- This implementation is only optimised for vercel and for self hosted platforms might need further investigation 
- Working demonstration [here](https://www.loom.com/share/0e58b48a336a43fdb0dfd2fe034cd1f4?sid=1497f14c-4ad8-472e-84ea-d9f8aaa704dc)
- This caching however isn't good enough for malicious attack, we could utilise cloudflare or aws cloudfront's security feature for that. 


